### PR TITLE
Upgrade rails5 1

### DIFF
--- a/app/controllers/styleguides_controller.rb
+++ b/app/controllers/styleguides_controller.rb
@@ -8,7 +8,7 @@ class StyleguidesController < ActionController::Base
 
   delegate :with_namespace, to: :view_context
 
-  before_filter :set_styleguide, :only => [ :show, :all ]
+  before_action :set_styleguide, :only => [ :show, :all ]
 
   def show
     @section = params[:section].to_i

--- a/nkss-rails.gemspec
+++ b/nkss-rails.gemspec
@@ -17,7 +17,7 @@ projects so you can instantly have cute docs."
   s.files = Dir["{app,config,lib}/**/*"] + ["Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.2.0"
+  s.add_dependency "rails", ">= 4.2.0"
 
   s.add_dependency "kss"
   s.add_dependency "ffaker"


### PR DESCRIPTION
`before_filter` は新しいRailsだと動かないので、 `before_action` に置き換える