### PR TITLE
warning occurs when using operator to color

### DIFF
--- a/app/assets/stylesheets/styleguide.sass
+++ b/app/assets/stylesheets/styleguide.sass
@@ -627,7 +627,7 @@ body.sg-full
     color: #a0afaf
 
   &.sg-expanded
-    background: #f0fafa * 0.95
+    background: #e4eeee
 
   &.sg-expanded:after
     content: '\25b2'


### PR DESCRIPTION
### 何が問題

sass 3.4.5から入った変更で、colorにoperatorを使って動的に結果を得ようとするとwarningが発生するようになりました。

https://github.com/sass/sass/issues/2144
https://github.com/sass/ruby-sass/commit/5d5899fa208c0fde51632927f4c9ab956d50a6c3


#### 具体例
![2018-10-30 19 05 52](https://user-images.githubusercontent.com/8204936/47711171-ea9a4d80-dc77-11e8-8037-c107a4cc8fd4.png)


### 変更したこと
動的による計算ではなく、計算結果をHexのままstaticに記述するようにしました

※頑張れば動的にも記述できそうですが、committerのコメントではstaticに定義することを言及していたため、それに従いました
https://github.com/sass/sass/issues/2501#issuecomment-380619131